### PR TITLE
Fixed containerd config :)

### DIFF
--- a/clusters/main/talos/talconfig.yaml
+++ b/clusters/main/talos/talconfig.yaml
@@ -69,12 +69,7 @@ controlPlane:
           - siderolabs/qemu-guest-agent
   machineFiles:
     - content: |
-        [plugins."io.containerd.grpc.v1.cri"]
-          enable_unprivileged_ports = true
-          enable_unprivileged_icmp = true
-        [plugins."io.containerd.grpc.v1.cri".containerd]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+        [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
       permissions: 0
       path: /etc/cri/conf.d/20-customization.part


### PR DESCRIPTION
The location of this configuration was changed in containerd 2.0 and also the other 2 settings for allowing unprivileged containers to use icmp and privileged ports are true by default now.