### PR TITLE
Revert "chore(flux): update image jellyfin 22.2.33 → 22.2.34"

### DIFF
--- a/clusters/main/kubernetes/my-apps/media/jellyfin/app/helm-release.yaml
+++ b/clusters/main/kubernetes/my-apps/media/jellyfin/app/helm-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: jellyfin
-      version: 22.2.34
+      version: 22.2.33
       sourceRef:
         kind: HelmRepository
         name: truecharts


### PR DESCRIPTION
Reverts nerddotdad/truecharts#1931

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-value version rollback in a HelmRelease; risk is limited to potential runtime differences from deploying the older chart version.
> 
> **Overview**
> Reverts the Jellyfin TrueCharts Helm chart bump by pinning the `jellyfin` `HelmRelease` back to version `22.2.33` (from `22.2.34`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96ee55a0f79e969ab6a36d1f403ff64445917ee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->